### PR TITLE
Added a Health-based ESP Box option.

### DIFF
--- a/src/ATGUI/Tabs/visualstab.cpp
+++ b/src/ATGUI/Tabs/visualstab.cpp
@@ -56,6 +56,8 @@ void Visuals::RenderTab()
 			ImGui::Columns(2, NULL, true);
 			{
 				ImGui::Checkbox(XORSTR("Outline Box"), &Settings::ESP::Boxes::enabled);
+				if (Settings::ESP::Boxes::enabled)
+					ImGui::Checkbox(XORSTR("Health-based Box"), &Settings::ESP::HealthBased::enabled);
 				ImGui::Checkbox(XORSTR("Chams"), &Settings::ESP::Chams::enabled);
 				ImGui::Checkbox(XORSTR("Health"), &Settings::ESP::Bars::enabled);
 				ImGui::Checkbox(XORSTR("Tracers"), &Settings::ESP::Tracers::enabled);
@@ -71,6 +73,8 @@ void Visuals::RenderTab()
 			{
 				ImGui::PushItemWidth(-1);
 				ImGui::Combo(XORSTR("##BOXTYPE"), (int*)& Settings::ESP::Boxes::type, BoxTypes, IM_ARRAYSIZE(BoxTypes));
+				if (Settings::ESP::Boxes::enabled)
+					ImGui::Text(XORSTR("")); // didnt know the correct way, but this works
 				ImGui::Combo(XORSTR("##CHAMSTYPE"), (int*)& Settings::ESP::Chams::type, ChamsTypes, IM_ARRAYSIZE(ChamsTypes));
 				ImGui::Combo(XORSTR("##BARTYPE"), (int*)& Settings::ESP::Bars::type, BarTypes, IM_ARRAYSIZE(BarTypes));
 				ImGui::Combo(XORSTR("##TRACERTYPE"), (int*)& Settings::ESP::Tracers::type, TracerTypes, IM_ARRAYSIZE(TracerTypes));
@@ -97,8 +101,11 @@ void Visuals::RenderTab()
 			{
 				ImGui::Checkbox(XORSTR("Allies"), &Settings::ESP::Filters::allies);
 				ImGui::Checkbox(XORSTR("Fish"), &Settings::ESP::Filters::fishes);
-				ImGui::Checkbox(XORSTR("Smoke Check"), &Settings::ESP::Filters::smokeCheck);
-				ImGui::Checkbox(XORSTR("Visiblity Check"), &Settings::ESP::Filters::visibilityCheck);
+				if (!Settings::ESP::HealthBased::enabled)
+				{
+					ImGui::Checkbox(XORSTR("Smoke Check"), &Settings::ESP::Filters::smokeCheck);
+					ImGui::Checkbox(XORSTR("Visiblity Check"), &Settings::ESP::Filters::visibilityCheck);
+				}
 			}
 			ImGui::Columns(1);
 			ImGui::Separator();

--- a/src/Hacks/esp.cpp
+++ b/src/Hacks/esp.cpp
@@ -69,6 +69,7 @@ bool Settings::ESP::Info::grabbingHostage = false;
 bool Settings::ESP::Info::rescuing = false;
 bool Settings::ESP::Info::location = false;
 bool Settings::ESP::Boxes::enabled = false;
+bool Settings::ESP::HealthBased::enabled = false;
 BoxType Settings::ESP::Boxes::type = BoxType::FRAME_2D;
 bool Settings::ESP::Bars::enabled = false;
 BarColorType Settings::ESP::Bars::colorType = BarColorType::HEALTH_BASED;
@@ -678,7 +679,11 @@ static void DrawPlayer(int index, C_BasePlayer* player, IEngineClient::player_in
 	if (!GetBox(player, x, y, w, h))
 		return;
 
-	if (Settings::ESP::Boxes::enabled)
+	int HealthValue = std::max(0, std::min(player->GetHealth(), 100));
+
+	if (Settings::ESP::Boxes::enabled && Settings::ESP::HealthBased::enabled)
+		DrawBox(Util::GetHealthColor(HealthValue), x, y, w, h, player);
+	else if (Settings::ESP::Boxes::enabled)
 		DrawBox(Color::FromImColor(playerColor), x, y, w, h, player);
 
 	int boxSpacing = Settings::ESP::Boxes::enabled ? 3 : 0;
@@ -689,8 +694,6 @@ static void DrawPlayer(int index, C_BasePlayer* player, IEngineClient::player_in
 	{
 		Color barColor;
 
-		// clamp it to 100
-		int HealthValue = std::max(0, std::min(player->GetHealth(), 100));
 		float HealthPerc = HealthValue / 100.f;
 
 		int barx = x;

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -293,6 +293,7 @@ void Settings::LoadDefaultsOrSave(std::string path)
 	settings[XORSTR("ESP")][XORSTR("Info")][XORSTR("location")] = Settings::ESP::Info::location;
 	settings[XORSTR("ESP")][XORSTR("Boxes")][XORSTR("enabled")] = Settings::ESP::Boxes::enabled;
 	settings[XORSTR("ESP")][XORSTR("Boxes")][XORSTR("type")] = (int) Settings::ESP::Boxes::type;
+	settings[XORSTR("ESP")][XORSTR("HealthBased")][XORSTR("enabled")] = Settings::ESP::HealthBased::enabled;
 	settings[XORSTR("ESP")][XORSTR("Skeleton")][XORSTR("enabled")] = Settings::ESP::Skeleton::enabled;
 	LoadColor(settings[XORSTR("ESP")][XORSTR("Skeleton")][XORSTR("color")], Settings::ESP::Skeleton::color);
 	settings[XORSTR("ESP")][XORSTR("Bars")][XORSTR("enabled")] = Settings::ESP::Bars::enabled;
@@ -717,6 +718,7 @@ void Settings::LoadConfig(std::string path)
 	GetVal(settings[XORSTR("ESP")][XORSTR("Info")][XORSTR("location")], &Settings::ESP::Info::location);
 	GetVal(settings[XORSTR("ESP")][XORSTR("Boxes")][XORSTR("enabled")], &Settings::ESP::Boxes::enabled);
 	GetVal(settings[XORSTR("ESP")][XORSTR("Boxes")][XORSTR("type")], (int*)& Settings::ESP::Boxes::type);
+	GetVal(settings[XORSTR("ESP")][XORSTR("HealthBased")][XORSTR("enabled")], &Settings::ESP::HealthBased::enabled);
 	GetVal(settings[XORSTR("ESP")][XORSTR("Skeleton")][XORSTR("enabled")], &Settings::ESP::Skeleton::enabled);
 	GetVal(settings[XORSTR("ESP")][XORSTR("Skeleton")][XORSTR("color")], &Settings::ESP::Skeleton::color);
 	GetVal(settings[XORSTR("ESP")][XORSTR("Bars")][XORSTR("enabled")], &Settings::ESP::Bars::enabled);

--- a/src/settings.h
+++ b/src/settings.h
@@ -622,6 +622,11 @@ namespace Settings
 			extern BoxType type;
 		}
 
+		namespace HealthBased
+		{
+			extern bool enabled;
+		}
+
 		namespace Bars
 		{
 			extern bool enabled;


### PR DESCRIPTION
This will set the color of the ESP Boxes according to the player's health. Remember that it will show enemies and allies the same way (based on their health), so it's recommended to only filter enemies. It will also "disable" the visibility check and smoke check from the filter options as they're useless with this option.