### PR TITLE
Improve load/rload/uload/update scripts

### DIFF
--- a/load
+++ b/load
@@ -2,21 +2,21 @@
 
 csgo_pid=$(pidof csgo_linux64)
 if [ -z "$csgo_pid" ]; then
-    /bin/echo -e "\e[31mCSGO needs to be open before you can inject...\e[0m"
+    /bin/echo -e "\e[31mCS:GO needs to be open before you can inject...\e[0m"
     exit 1
 fi
 
 if [ ! -d ".git" ]; then
-    /bin/echo "We have detected that you have downloaded AimTux-Fuzion .zip from the GitHub website. This is the WRONG way to download! Please download AimTux-Fuzion with the command 'git clone --recursive https://github.com/LWSS/Fuzion'"
+    /bin/echo "We have detected that you have downloaded Fuzion-master.zip from GitHub.com. This is the WRONG way to download! Please download Fuzion by cloning the Git repository: 'git clone --recursive https://github.com/LWSS/Fuzion.git'"
 fi
 
 # pBypass for crash dumps being sent
-sudo rm -rf /tmp/dumps # Remove if it's there
+sudo rm -rf /tmp/dumps # Remove if it exists
 sudo mkdir /tmp/dumps # Make it as root
 sudo chmod 000 /tmp/dumps # No permissions
 
 if [ ! -f build_id ]; then
-    /bin/echo "build ID not found. Please re-build using the ./build script"
+    /bin/echo "Build ID not found. Please rebuild using the './build' script."
     exit
 fi
 
@@ -24,7 +24,7 @@ filename=$(cat build_id)
 
 #Credit: Aixxe @ aixxe.net
 if grep -q $filename /proc/$csgo_pid/maps; then
-    /bin/echo -e "\e[33mAimTux-Fuzion is already injected... Aborting...\e[0m"
+    /bin/echo -e "\e[33mFuzion is already injected... Aborting...\e[0m"
     exit
 fi
 echo "Injecting Build ID: $filename"
@@ -35,7 +35,7 @@ sudo echo "2" | sudo tee /proc/sys/kernel/yama/ptrace_scope # Only allows root t
 sudo cp $filename /$filename
 
 input="$(
-sudo gdb -n -q -batch \
+sudo gdb -n -q -batch-silent \
   -ex "attach $csgo_pid" \
   -ex "set \$dlopen = (void*(*)(char*, int)) dlopen" \
   -ex "call \$dlopen(\"/$filename\", 1)" \
@@ -50,5 +50,5 @@ last_line="${input##*$'\n'}"
 if [ "$last_line" != "\$1 = (void *) 0x0" ]; then
     /bin/echo -e "\e[32mSuccessfully injected!\e[0m"
 else
-    /bin/echo -e "\e[31mInjection failed, make sure you've compiled...\e[0m"
+    /bin/echo -e "\e[31mInjection failed, make sure you have compiled...\e[0m"
 fi

--- a/rload
+++ b/rload
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-sudo bash -c "./uload && ./build && ./load" # The game crashes sometimes when reloading too quick :^( 
+sudo bash -c "./uload && ./build && ./load" # The game crashes sometimes when reloading too quick :^(

--- a/uload
+++ b/uload
@@ -2,38 +2,39 @@
 
 #Credit: Aixxe @ aixxe.net
 
+csgo_pid=$(pidof csgo_linux64)
+filename=$(cat build_id)
+filename_old=$(cat build_id_old)
 
 if [ -f build_id ]; then
-    if grep -q $(cat build_id) /proc/$(pidof csgo_linux64)/maps; then
-    sudo gdb -n -q -batch \
-        -ex "attach $(pidof csgo_linux64)" \
+    if grep -q $filename /proc/$csgo_pid/maps; then
+    sudo gdb -n -q -batch-silent \
+        -ex "attach $csgo_pid" \
         -ex "set \$dlopen = (void*(*)(char*, int)) dlopen" \
         -ex "set \$dlclose = (int(*)(void*)) dlclose" \
-        -ex "set \$library = \$dlopen(\"/$(cat build_id)\", 6)" \
+        -ex "set \$library = \$dlopen(\"/$filename\", 6)" \
         -ex "call \$dlclose(\$library)" \
         -ex "call \$dlclose(\$library)" \
         -ex "detach" \
         -ex "quit"
-    sudo rm /$(cat build_id)
+    sudo rm /$filename
     fi
 fi
 
-#build_id_old is used for unloading in case you re-build while injected. 
+#build_id_old is used for unloading in case you rebuild while injected.
 if [ -f build_id_old ]; then
-	if grep -q $(cat build_id_old) /proc/$(pidof csgo_linux64)/maps; then
-	sudo gdb -n -q -batch \
-	    -ex "attach $(pidof csgo_linux64)" \
-	    -ex "set \$dlopen = (void*(*)(char*, int)) dlopen" \
-	    -ex "set \$dlclose = (int(*)(void*)) dlclose" \
-	    -ex "set \$library = \$dlopen(\"/$(cat build_id_old)\", 6)" \
-	    -ex "call \$dlclose(\$library)" \
-	    -ex "call \$dlclose(\$library)" \
-	    -ex "detach" \
-	    -ex "quit"
-
-    sudo rm /$(cat build_id_old)
-	fi
-
+    if grep -q $filename_old /proc/$csgo_pid/maps; then
+    sudo gdb -n -q -batch-silent \
+        -ex "attach $csgo_pid" \
+        -ex "set \$dlopen = (void*(*)(char*, int)) dlopen" \
+        -ex "set \$dlclose = (int(*)(void*)) dlclose" \
+        -ex "set \$library = \$dlopen(\"/$filename_old\", 6)" \
+        -ex "call \$dlclose(\$library)" \
+        -ex "call \$dlclose(\$library)" \
+        -ex "detach" \
+        -ex "quit"
+    sudo rm /$filename_old
+    fi
 fi
 
 echo "Done. See CSGO Console."

--- a/update
+++ b/update
@@ -1,6 +1,7 @@
 #!/bin/bash
+
 if [ ! -d ".git" ]; then
-    echo ".git folder missing. Do NOT download the repo as a zip file from github! Please re-download AimTux-Fuzion with the command 'git clone --recursive https://github.com/LWSS/AimTux-Fuzion.git' into a new folder."
+    echo "Not a git repository (or any of the parent directories): .git. Do NOT download the repository as a zip file from GitHub.com! Please download Fuzion by cloning the Git repository: 'git clone --recursive https://github.com/LWSS/Fuzion.git'"
     exit
 else
     git pull


### PR DESCRIPTION
- Use "-batch-silent" instead of "-batch", so all GDB output to stdout
is prevented.

- Code more friendly (so ./uload is ./load alike).

- Minor formatting improvements and typo fixes.