### PR TITLE
"RCS always on" fix.

### DIFF
--- a/src/Hacks/aimbot.cpp
+++ b/src/Hacks/aimbot.cpp
@@ -842,10 +842,6 @@ void Aimbot::CreateMove(CUserCmd* cmd)
         lastRandom = {0,0,0};
     }
 
-    if( !shouldAim )// Not going to Aimlock.
-        return;
-
-
     AimStep(player, angle, cmd);
 	AutoCrouch(player, cmd);
 	AutoSlow(player, oldForward, oldSideMove, bestDamage, activeWeapon, cmd);


### PR DESCRIPTION
After the last update, a shouldaim check broke the RCS when you're not actually within aimbot triggering parameters. Didn't check if any of the step functions below have changed. If they did, maybe additional testing is needed.

Fixes #200 