### PR TITLE
load x64 systems

### DIFF
--- a/load
+++ b/load
@@ -33,7 +33,15 @@ echo "Injecting Build ID: $filename"
 # https://www.kernel.org/doc/Documentation/security/Yama.txt
 sudo echo "2" | sudo tee /proc/sys/kernel/yama/ptrace_scope # Only allows root to inject code. This is temporary until reboot.
 
-sudo cp "$filename" "/usr/lib64/${filename}"
+MACHINE_TYPE=`uname -m`
+if [ ${MACHINE_TYPE} == 'x86_64' ]; then
+  LIB_PATH="/usr/lib";
+else
+  LIB_PATH="/usr/lib64";
+fi
+
+
+sudo cp "$filename" "${LIB_PATH}/${filename}"
 
 sudo killall -19 steam
 sudo killall -19 steamwebhelper
@@ -45,7 +53,7 @@ sudo gdb -n -q -batch-silent \
   -ex "set logging redirect on" \
   -ex "attach $csgo_pid" \
   -ex "set \$dlopen = (void*(*)(char*, int)) dlopen" \
-  -ex "call \$dlopen(\"/usr/lib64/$filename\", 1)" \
+  -ex "call \$dlopen(\"${LIB_PATH}/$filename\", 1)" \
   -ex "detach" \
   -ex "quit"
 )"
@@ -54,7 +62,7 @@ sleep 1
 sudo killall -18 steamwebhelper
 sudo killall -18 steam
 
-sudo rm "/usr/lib64/${filename}"
+sudo rm "${LIB_PATH}/${filename}"
 
 last_line="${input##*$'\n'}"
 


### PR DESCRIPTION
i tested on x64 bit system yesterday, had issue with preload.cpp/.h, but looks like u already fixed it, i've replaced with code before 'Fix for gcc-8', it build. 
Todays issue i had: ./load didnt work, cuz x64 linux hasnt /usr/lib64, just replace it with /usr/lib.