### PR TITLE
Fix compiler optimizing decrypt xorstring function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 2.8)
 project(Fuzion)
+set(CMAKE_CXX_STANDARD 17)
 
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.2)
@@ -24,8 +25,10 @@ FUNCTION (EXCLUDE_FILES_FROM_DIR_IN_LIST _InFileList _excludeDirName _verbose)
     set(SOURCE_FILES ${_InFileList} PARENT_SCOPE) # Return the SOURCE_FILES variable to the calling parent
 ENDFUNCTION (EXCLUDE_FILES_FROM_DIR_IN_LIST)
 
-set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O3 -g -std=c++17 -Wall -ldl -fpic -shared")
-set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3 -std=c++17 -Wall -ldl -fpic -shared")
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -Wall -ldl -fpic")
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -ggdb")
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -s -fvisibility=hidden -fvisibility-inlines-hidden")
 #set(CMAKE_CXX_FLAGS_MINSIZEREL "${CMAKE_CXX_FLAGS_MINSIZEREL} -std=c++17 -Wall -Wno-maybe-uninitialized -Wno-unused-result -ldl -fpic -shared")
 
 set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS}")

--- a/README.md
+++ b/README.md
@@ -28,15 +28,15 @@ If you are having problems compiling make sure you've got the latest version of 
 
 __Ubuntu-Based / Debian:__
 ```bash
-sudo apt-get install cmake g++ gdb git libsdl2-dev zlib1g-dev liblua5.3 libxdo-dev patchelf libv8-dev
+sudo apt-get install cmake g++ gdb git libsdl2-dev zlib1g-dev liblua5.3 libxdo-dev patchelf
 ```
 __Arch:__
 ```bash
-sudo pacman -S base-devel cmake gdb git sdl2 lua xdotool patchelf v8
+sudo pacman -S base-devel cmake gdb git sdl2 lua xdotool patchelf
 ```
 __Fedora:__
 ```bash
-sudo dnf install cmake gcc-c++ gdb git libstdc++-static mesa-libGL-devel SDL2-devel zlib-devel lua-devel libX11-devel libxdo-devel patchelf v8-devel
+sudo dnf install cmake gcc-c++ gdb git libstdc++-static mesa-libGL-devel SDL2-devel zlib-devel lua-devel libX11-devel libxdo-devel patchelf
 ```
 
 ===================

--- a/src/SDK/panorama/IUIEvent.h
+++ b/src/SDK/panorama/IUIEvent.h
@@ -1,6 +1,6 @@
 #pragma once
 #include "IUIPanel.h"
-#include <v8.h>
+//#include <v8.h>
 namespace panorama
 {
     class IUIEvent

--- a/src/Utils/xorstring.h
+++ b/src/Utils/xorstring.h
@@ -73,7 +73,7 @@ namespace Util
 				: Value{ EncryptCharacter(String[Index], Index)... } {}
 
 		char* decrypt() {
-			for(unsigned int t = 0; t < sizeof...(Index); t++) {
+			for(volatile unsigned int t = 0; t < sizeof...(Index); t++) {
 				Value[t] = Value[t] ^ (XORKEY + t);
 			}
 			Value[sizeof...(Index)] = '\0';


### PR DESCRIPTION
nullworks/cathook#487 got me interested in using xorstrings. After implementing them in a test project and reverse engineering it, I discovered that the string was still visible (most likely due to compile time optimization). Adding a volatile statement to the loop fixes this problem. (NOTE: I did not test these changes in fuzion (only in nullworks/cathook))