### PR TITLE
Fix "./update-force" / Remove bad build names

### DIFF
--- a/build_names
+++ b/build_names
@@ -239,7 +239,6 @@ libbytesize.so
 libbz2.so
 libbz2.so
 libbz2.so
-libc-2.24.so
 libcacard.so
 libcacard.so
 libcairo-gobject.so

--- a/build_names
+++ b/build_names
@@ -1169,8 +1169,6 @@ libhogweed.so
 libhogweed.so
 libhpdiscovery.so
 libhpdiscovery.so
-libhpipp.so
-libhpipp.so
 libhpip.so
 libhpip.so
 libhpmud.so

--- a/build_names
+++ b/build_names
@@ -2888,9 +2888,6 @@ libxapian.so
 libxapian.so
 libxatracker.so
 libxatracker.so
-libXau.so
-libXau.so
-libXau.so
 libXaw7.so
 libXaw7.so
 libXaw.so

--- a/update-force
+++ b/update-force
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-if [ ! -d ".git" ]; then
+if [ -d ".git" ]; then
     read -p "This will delete local code changes. Are you sure? (y/n)" -n 1 -r
     echo
     if [[ $REPLY =~ ^[Yy]$ ]]


### PR DESCRIPTION
Build name `libXau.so` gives `Fuzion is already injected, aborting...` when trying to load. 

`./uload` with `libXau.so` crashes the game to desktop.

`./update-force` fixes https://github.com/LWSS/Fuzion/issues/369