### PR TITLE
Third-person fix

### DIFF
--- a/src/ATGUI/Tabs/misctab.cpp
+++ b/src/ATGUI/Tabs/misctab.cpp
@@ -28,6 +28,7 @@ void Misc::RenderTab()
 	const char* teams[] = { "Allies", "Enemies", "Both" };
 	const char* grenadeTypes[] = { "FLASH", "SMOKE", "MOLOTOV", "HEGRENADE" };
 	const char* throwTypes[] = { "NORMAL", "RUN", "JUMP", "WALK" };
+	const char* angleTypes[] = { "Real", "Fake" };
 
 	ImGui::Columns(2, nullptr, true);
 	{
@@ -223,11 +224,13 @@ void Misc::RenderTab()
 			ImGui::Columns(2, nullptr, true);
 			{
 				ImGui::Checkbox(XORSTR("Enabled"), &Settings::ThirdPerson::enabled);
+			    ImGui::Text(XORSTR("Showed Angle"));
 			}
 			ImGui::NextColumn();
 			{
 				ImGui::PushItemWidth(-1);
 				ImGui::SliderFloat(XORSTR("##TPCAMOFFSET"), &Settings::ThirdPerson::distance, 0.f, 500.f, XORSTR("Camera Offset: %0.f"));
+                ImGui::Combo(XORSTR("Showed Angle"), (int*)& Settings::ThirdPerson::type, angleTypes, IM_ARRAYSIZE(angleTypes));
 				ImGui::PopItemWidth();
 			}
 			ImGui::Columns(1);

--- a/src/Hacks/angleindicator.cpp
+++ b/src/Hacks/angleindicator.cpp
@@ -24,7 +24,7 @@ void AngleIndicator::Paint( ) {
     int northY = centerY - radius;
 
     float maxDesync = AntiAim::GetMaxDelta( localPlayer->GetAnimState() );
-    float realDiff = AntiAim::lastFakeYaw - AntiAim::lastRealYaw;
+    float realDiff = AntiAim::fakeAngle.y - AntiAim::realAngle.y;
     float lbyDiff = localPlayer->GetVAngles()->y - *localPlayer->GetLowerBodyYawTarget();
     Math::NormalizeYaw( realDiff );
     Math::NormalizeYaw( lbyDiff );

--- a/src/Hacks/antiaim.cpp
+++ b/src/Hacks/antiaim.cpp
@@ -23,8 +23,8 @@ bool Settings::AntiAim::AutoDisable::knifeHeld = false;
 bool Settings::AntiAim::LBYBreaker::enabled = false;
 float Settings::AntiAim::LBYBreaker::offset = 180.0f;
 
-float AntiAim::lastRealYaw = 0.0f;
-float AntiAim::lastFakeYaw = 0.0f;
+QAngle AntiAim::realAngle;
+QAngle AntiAim::fakeAngle;
 
 float AntiAim::GetMaxDelta( CCSGOAnimState *animState ) {
 
@@ -124,10 +124,10 @@ static void DoAntiAimY(C_BasePlayer *const localplayer, QAngle& angle, bool bSen
     switch (aa_type)
     {
         case AntiAimType_Y::MAX_DELTA_LEFT:
-            angle.y = AntiAim::lastFakeYaw - maxDelta;
+            angle.y = AntiAim::fakeAngle.y - maxDelta;
             break;
         case AntiAimType_Y::MAX_DELTA_RIGHT:
-            angle.y = AntiAim::lastFakeYaw + maxDelta;
+            angle.y = AntiAim::fakeAngle.y + maxDelta;
             break;
         case AntiAimType_Y::MAX_DELTA_FLIPPER:
             bFlip = !bFlip;
@@ -140,9 +140,9 @@ static void DoAntiAimY(C_BasePlayer *const localplayer, QAngle& angle, bool bSen
             break;
     }
     if( bSend ){
-        AntiAim::lastFakeYaw = angle.y;
+        AntiAim::fakeAngle.y = angle.y;
     } else {
-        AntiAim::lastRealYaw = angle.y;
+        AntiAim::realAngle.y = angle.y;
     }
 }
 
@@ -205,6 +205,8 @@ void AntiAim::CreateMove(CUserCmd* cmd)
     QAngle oldAngle = cmd->viewangles;
     float oldForward = cmd->forwardmove;
     float oldSideMove = cmd->sidemove;
+    
+    AntiAim::realAngle = AntiAim::fakeAngle = CreateMove::lastTickViewAngles;
 
     QAngle angle = cmd->viewangles;
 

--- a/src/Hacks/antiaim.h
+++ b/src/Hacks/antiaim.h
@@ -5,9 +5,8 @@
 
 namespace AntiAim
 {
-    extern float lastRealYaw;
-    extern float lastFakeYaw;
-
+    extern QAngle realAngle;
+    extern QAngle fakeAngle;
 
     float GetMaxDelta( CCSGOAnimState *animState );
 

--- a/src/Hacks/thirdperson.h
+++ b/src/Hacks/thirdperson.h
@@ -1,9 +1,11 @@
 #pragma once
 
 #include "../SDK/CViewRender.h"
+#include "../Hooks/hooks.h"
 
 namespace ThirdPerson
 {
 	//Hooks
 	void OverrideView(CViewSetup* pSetup);
+	void FrameStageNotify(ClientFrameStage_t stage);
 }

--- a/src/Hooks/FrameStageNotify.cpp
+++ b/src/Hooks/FrameStageNotify.cpp
@@ -10,6 +10,7 @@
 #include "../Hacks/skybox.h"
 #include "../Hacks/asuswalls.h"
 #include "../Hacks/nosmoke.h"
+#include "../Hacks/thirdperson.h"
 
 typedef void (*FrameStageNotifyFn) (void*, ClientFrameStage_t);
 
@@ -24,6 +25,7 @@ void Hooks::FrameStageNotify(void* thisptr, ClientFrameStage_t stage)
 	SkyBox::FrameStageNotify(stage);
 	ASUSWalls::FrameStageNotify(stage);
 	NoSmoke::FrameStageNotify(stage);
+	ThirdPerson::FrameStageNotify(stage);
 
 	if (SkinChanger::forceFullUpdate)
 	{

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -601,6 +601,7 @@ void Settings::LoadDefaultsOrSave(std::string path)
 
 	settings[XORSTR("ThirdPerson")][XORSTR("enabled")] = Settings::ThirdPerson::enabled;
 	settings[XORSTR("ThirdPerson")][XORSTR("distance")] = Settings::ThirdPerson::distance;
+	settings[XORSTR("ThirdPerson")][XORSTR("type")] = (int) Settings::ThirdPerson::type;
 
 	settings[XORSTR("JumpThrow")][XORSTR("enabled")] = Settings::JumpThrow::enabled;
 	settings[XORSTR("JumpThrow")][XORSTR("key")] = Util::GetButtonName(Settings::JumpThrow::key);
@@ -1173,6 +1174,7 @@ void Settings::LoadConfig(std::string path)
 
 	GetVal(settings[XORSTR("ThirdPerson")][XORSTR("enabled")], &Settings::ThirdPerson::enabled);
 	GetVal(settings[XORSTR("ThirdPerson")][XORSTR("distance")], &Settings::ThirdPerson::distance);
+	GetVal(settings[XORSTR("ThirdPerson")][XORSTR("type")], (int*)&Settings::ThirdPerson::type);
 
 	GetVal(settings[XORSTR("JumpThrow")][XORSTR("enabled")], &Settings::JumpThrow::enabled);
 	GetButtonCode(settings[XORSTR("JumpThrow")][XORSTR("key")], &Settings::JumpThrow::key);

--- a/src/settings.h
+++ b/src/settings.h
@@ -145,6 +145,12 @@ enum class SpammerType : int
 	SPAMMER_POSITIONS,
 };
 
+enum class ShowedAngle : int
+{
+    REAL,
+    FAKE,
+};
+
 enum class AntiAimType_Y : int
 {
 	NONE,
@@ -1084,6 +1090,7 @@ namespace Settings
 	{
 		extern bool enabled;
 		extern float distance;
+        extern ShowedAngle type;
 	}
 
 	namespace JumpThrow


### PR DESCRIPTION
Just fixed third-person. It's now working properly with some minor tweaks. Also, it now shows anti-aim angles, and you can choose which angle you want to see. Later on, I want to recode my deleted anti-aim which I'll PR to this repo. On local-servers, without `sv_cheats 1` the player model might flicker.