### PR TITLE
build: check os version & missing packages

### DIFF
--- a/build
+++ b/build
@@ -6,7 +6,7 @@ if [ -f /etc/os-release ]; then
     DISTRO=$NAME
     if [ "$DISTRO"=="Arch Linux" ]; then
         if ! pacman -Qq cmake gdb git sdl2 patchelf  &>/dev/null; then
-            echo "Missing package(s). Please make sure you have installed all required packages."
+            echo "Missing package(s). Please make sure you have installed all required build dependencies."
             read -p "Do you still want to build? (Y/n)" -n 1 -r
             echo
             if [[ $REPLY =~ ^[Nn]$ ]]; then
@@ -16,7 +16,7 @@ if [ -f /etc/os-release ]; then
     elif [ "$DISTRO"=="Ubuntu" ]; then
     # Should be `dpkg-query -s`? Does this fail with a missing package?`
         if ! dpkg -s cmake g++ gdb git libsdl2-dev zlib1g-dev patchelf  &>/dev/null; then
-            echo "Missing package(s). Please make sure you have installed all required packages."
+            echo "Missing package(s). Please make sure you have installed all required build dependencies."
             read -p "Do you still want to build? (Y/n)" -n 1 -r
             echo
             if [[ $REPLY =~ ^[Nn]$ ]]; then
@@ -26,7 +26,7 @@ if [ -f /etc/os-release ]; then
     elif [ "$DISTRO"=="Fedora" ]; then
     # Does a missing package produce an error with `dnf check`?
         if ! dnf check cmake gcc-c++ gdb git libstdc++-static mesa-libGL-devel SDL2-devel zlib-devel libX11-devel patchelf  &>/dev/null; then
-            echo "Missing package(s). Please make sure you have installed all required packages."
+            echo "Missing package(s). Please make sure you have installed all required build dependencies."
             read -p "Do you still want to build? (Y/n)" -n 1 -r
             echo
             if [[ $REPLY =~ ^[Nn]$ ]]; then

--- a/build
+++ b/build
@@ -14,7 +14,6 @@ if [ -f /etc/os-release ]; then
             fi
         fi
     elif [[ "$DISTRO"=="Ubuntu" ]] || [[ "$DISTRO"=="Debian GNU/Linux" ]]; then
-    # Should be `dpkg-query -s`? Does this fail with a missing package?`
         if ! dpkg -s cmake g++ gdb git libsdl2-dev zlib1g-dev patchelf  &>/dev/null; then
             echo "Missing package(s). Please make sure you have installed all required build dependencies."
             read -p "Do you still want to build? (Y/n)" -n 1 -r

--- a/build
+++ b/build
@@ -4,7 +4,7 @@
 if [ -f /etc/os-release ]; then
     . /etc/os-release
     DISTRO=$NAME
-    if [[ "$DISTRO"=="Arch Linux" && "$DISTRO"=="Antergos Linux" && "$DISTRO"=="Manjaro Linux" ]]; then
+    if [[ "$DISTRO"=="Arch Linux" ]] || [[ "$DISTRO"=="Antergos Linux" ]] || [[ "$DISTRO"=="Manjaro Linux" ]]; then
         if ! pacman -Qq cmake gdb git sdl2 patchelf  &>/dev/null; then
             echo "Missing package(s). Please make sure you have installed all required build dependencies."
             read -p "Do you still want to build? (Y/n)" -n 1 -r
@@ -13,7 +13,7 @@ if [ -f /etc/os-release ]; then
                 exit 1
             fi
         fi
-    elif [[ "$DISTRO"=="Ubuntu" && "$DISTRO"=="Debian GNU/Linux" ]]; then
+    elif [[ "$DISTRO"=="Ubuntu" ]] || [[ "$DISTRO"=="Debian GNU/Linux" ]]; then
     # Should be `dpkg-query -s`? Does this fail with a missing package?`
         if ! dpkg -s cmake g++ gdb git libsdl2-dev zlib1g-dev patchelf  &>/dev/null; then
             echo "Missing package(s). Please make sure you have installed all required build dependencies."
@@ -23,7 +23,7 @@ if [ -f /etc/os-release ]; then
                 exit 1
             fi
         fi
-    elif [ "$DISTRO"=="Fedora" ]; then
+    elif [[ "$DISTRO"=="Fedora" ]]; then
     # Does a missing package produce an error with `dnf check`?
         if ! dnf check cmake gcc-c++ gdb git libstdc++-static mesa-libGL-devel SDL2-devel zlib-devel libX11-devel patchelf  &>/dev/null; then
             echo "Missing package(s). Please make sure you have installed all required build dependencies."

--- a/build
+++ b/build
@@ -4,7 +4,7 @@
 if [ -f /etc/os-release ]; then
     . /etc/os-release
     DISTRO=$NAME
-    if [ "$DISTRO"=="Arch Linux" ]; then
+    if [[ "$DISTRO"=="Arch Linux" && "$DISTRO"=="Antergos Linux" && "$DISTRO"=="Manjaro Linux" ]]; then
         if ! pacman -Qq cmake gdb git sdl2 patchelf  &>/dev/null; then
             echo "Missing package(s). Please make sure you have installed all required build dependencies."
             read -p "Do you still want to build? (Y/n)" -n 1 -r
@@ -13,7 +13,7 @@ if [ -f /etc/os-release ]; then
                 exit 1
             fi
         fi
-    elif [ "$DISTRO"=="Ubuntu" ]; then
+    elif [[ "$DISTRO"=="Ubuntu" && "$DISTRO"=="Debian GNU/Linux" ]]; then
     # Should be `dpkg-query -s`? Does this fail with a missing package?`
         if ! dpkg -s cmake g++ gdb git libsdl2-dev zlib1g-dev patchelf  &>/dev/null; then
             echo "Missing package(s). Please make sure you have installed all required build dependencies."

--- a/build
+++ b/build
@@ -1,5 +1,40 @@
 #!/usr/bin/env bash
-#TODO: check distro and packages
+
+# Check for installed packages
+if [ -f /etc/os-release ]; then
+    . /etc/os-release
+    DISTRO=$NAME
+    if [ "$DISTRO"=="Arch Linux" ]; then
+        if ! pacman -Qq cmake gdb git sdl2 patchelf  &>/dev/null; then
+            echo "Missing package(s). Please make sure you have installed all required packages."
+            read -p "Do you still want to build? (Y/n)" -n 1 -r
+            echo
+            if [[ $REPLY =~ ^[Nn]$ ]]; then
+                exit 1
+            fi
+        fi
+    elif [ "$DISTRO"=="Ubuntu" ]; then
+    # Should be `dpkg-query -s`? Does this fail with a missing package?`
+        if ! dpkg -s cmake g++ gdb git libsdl2-dev zlib1g-dev patchelf  &>/dev/null; then
+            echo "Missing package(s). Please make sure you have installed all required packages."
+            read -p "Do you still want to build? (Y/n)" -n 1 -r
+            echo
+            if [[ $REPLY =~ ^[Nn]$ ]]; then
+                exit 1
+            fi
+        fi
+    elif [ "$DISTRO"=="Fedora" ]; then
+    # Does a missing package produce an error with `dnf check`?
+        if ! dnf check cmake gcc-c++ gdb git libstdc++-static mesa-libGL-devel SDL2-devel zlib-devel libX11-devel patchelf  &>/dev/null; then
+            echo "Missing package(s). Please make sure you have installed all required packages."
+            read -p "Do you still want to build? (Y/n)" -n 1 -r
+            echo
+            if [[ $REPLY =~ ^[Nn]$ ]]; then
+                exit 1
+            fi
+        fi
+    fi
+fi
 
 function echo_orange {
 	echo -e "\\e[33m$*\\e[0m"

--- a/build
+++ b/build
@@ -13,7 +13,7 @@ if [ -f /etc/os-release ]; then
                 exit 1
             fi
         fi
-    elif [[ "$DISTRO"=="Ubuntu" ]] || [[ "$DISTRO"=="Debian GNU/Linux" ]]; then
+    elif [[ "$DISTRO"==*"buntu"* ]] || [[ "$DISTRO"=="Pop!_OS" ]] || [[ "$DISTRO"=="Debian GNU/Linux" ]]; then
         if ! dpkg -s cmake g++ gdb git libsdl2-dev zlib1g-dev patchelf  &>/dev/null; then
             echo "Missing package(s). Please make sure you have installed all required build dependencies."
             read -p "Do you still want to build? (Y/n)" -n 1 -r
@@ -22,8 +22,7 @@ if [ -f /etc/os-release ]; then
                 exit 1
             fi
         fi
-    elif [[ "$DISTRO"=="Fedora" ]]; then
-    # Does a missing package produce an error with `dnf check`?
+    elif [[ "$DISTRO"==*"Fedora"* ]]; then
         if ! dnf check cmake gcc-c++ gdb git libstdc++-static mesa-libGL-devel SDL2-devel zlib-devel libX11-devel patchelf  &>/dev/null; then
             echo "Missing package(s). Please make sure you have installed all required build dependencies."
             read -p "Do you still want to build? (Y/n)" -n 1 -r

--- a/build
+++ b/build
@@ -5,7 +5,7 @@ if [ -f /etc/os-release ]; then
     . /etc/os-release
     DISTRO=$NAME
     if [[ "$DISTRO"=="Arch Linux" ]] || [[ "$DISTRO"=="Antergos Linux" ]] || [[ "$DISTRO"=="Manjaro Linux" ]]; then
-        if ! pacman -Qq cmake gdb git sdl2 patchelf  &>/dev/null; then
+        if ! pacman -Qq cmake gdb gcc git sdl2 patchelf  &>/dev/null; then
             echo "Missing package(s). Please make sure you have installed all required build dependencies."
             read -p "Do you still want to build? (Y/n)" -n 1 -r
             echo


### PR DESCRIPTION
I'm not sure if the if statement for Ubuntu & Fedora will return and error if a package is not recognised when querying. This is what happens on Arch, and so the if statement succeeds without needing to check the output for individual packages with `grep` or something.

I can't find examples of a missing/wrong package being entered into `dpkg -s` & `dnf check`, so if someone could do that for me it would be great. Might just need to grep the output.

Commented where I'm not sure.