### PR TITLE
Simplified Anti-Aim (Work in-progress!)

### DIFF
--- a/src/ATGUI/Tabs/hvhtab.cpp
+++ b/src/ATGUI/Tabs/hvhtab.cpp
@@ -10,99 +10,11 @@
 
 void HvH::RenderTab()
 {
-    const char* yTypes[] = {
-            "NONE", "MAX_DELTA_LEFT", "MAX_DELTA_RIGHT", "MAX_DELTA_FLIPPER", "MAX_DELTA_LBY_AVOID"
-    };
-
-    const char* xTypes[] = {
-            "UP", "DOWN", "DANCE", "FRONT", // safe
-            "FAKE UP", "FAKE DOWN", "LISP DOWN", "ANGEL DOWN", "ANGEL UP" // untrusted
-    };
-
     ImGui::Columns(2, nullptr, true);
     {
         ImGui::BeginChild(XORSTR("HVH1"), ImVec2(0, 0), true);
         {
-            ImGui::Text(XORSTR("AntiAim"));
-            ImGui::BeginChild(XORSTR("##ANTIAIM"), ImVec2(0, 0), true);
-            {
-                ImGui::Checkbox(XORSTR("Yaw"), &Settings::AntiAim::Yaw::enabled);
-                ImGui::Separator();
-                ImGui::Columns(2, nullptr, true);
-                {
-                    ImGui::ItemSize(ImVec2(0.0f, 0.0f), 0.0f);
-                    ImGui::Text(XORSTR("Yaw Fake"));
-                    ImGui::ItemSize(ImVec2(0.0f, 0.0f), 0.0f);
-                    ImGui::Text(XORSTR("Yaw Actual"));
-                }
-                ImGui::NextColumn();
-                {
-                    ImGui::PushItemWidth(-1);
-                    ImGui::Combo(XORSTR("##YFAKETYPE"), (int*)& Settings::AntiAim::Yaw::typeFake, yTypes, IM_ARRAYSIZE(yTypes));
-
-                    ImGui::Combo(XORSTR("##YACTUALTYPE"), (int*)& Settings::AntiAim::Yaw::type, yTypes, IM_ARRAYSIZE(yTypes));
-                    ImGui::PopItemWidth();
-                }
-                ImGui::Columns(1);
-                ImGui::Separator();
-                ImGui::Checkbox(XORSTR("Pitch"), &Settings::AntiAim::Pitch::enabled);
-                ImGui::Separator();
-                ImGui::Columns(2, nullptr, true);
-                {
-                    ImGui::ItemSize(ImVec2(0.0f, 0.0f), 0.0f);
-                    ImGui::Text(XORSTR("Pitch Actual"));
-                }
-                ImGui::NextColumn();
-                {
-                    ImGui::PushItemWidth(-1);
-                    if (ImGui::Combo(XORSTR("##XTYPE"), (int*)& Settings::AntiAim::Pitch::type, xTypes, IM_ARRAYSIZE(xTypes)))
-                    {
-                        if (!ValveDSCheck::forceUT && ((*csGameRules) && (*csGameRules)->IsValveDS()) && Settings::AntiAim::Pitch::type >= AntiAimType_X::STATIC_UP_FAKE)
-                        {
-                            Settings::AntiAim::Pitch::type = AntiAimType_X::STATIC_UP;
-                            ImGui::OpenPopup(XORSTR("Error###UNTRUSTED_AA"));
-                        }
-                    }
-                    ImGui::PopItemWidth();
-                }
-                ImGui::Columns(1);
-                ImGui::Separator();
-                ImGui::Text(XORSTR("Disable"));
-                ImGui::Separator();
-                ImGui::Checkbox(XORSTR("Knife"), &Settings::AntiAim::AutoDisable::knifeHeld);
-                ImGui::Checkbox(XORSTR("No Enemy"), &Settings::AntiAim::AutoDisable::noEnemy);
-
-                ImGui::Columns(1);
-                ImGui::Separator();
-                ImGui::Text(XORSTR("Edging"));
-                ImGui::Separator();
-                ImGui::Columns(2, nullptr, true);
-                {
-                    ImGui::Checkbox(XORSTR("Enabled"), &Settings::AntiAim::HeadEdge::enabled);
-                }
-                ImGui::NextColumn();
-                {
-                    ImGui::PushItemWidth(-1);
-                    ImGui::SliderFloat(XORSTR("##EDGEDISTANCE"), &Settings::AntiAim::HeadEdge::distance, 20, 30, "Distance: %0.f");
-                    ImGui::PopItemWidth();
-                }
-                ImGui::Columns(1);
-                ImGui::PushStyleVar(ImGuiStyleVar_WindowMinSize, ImVec2(210, 85));
-                if (ImGui::BeginPopupModal(XORSTR("Error###UNTRUSTED_AA")))
-                {
-                    ImGui::Text(XORSTR("You cannot use this antiaim type on a VALVE server."));
-
-                    ImGui::Checkbox(XORSTR("This is not a VALVE server"), &ValveDSCheck::forceUT);
-
-                    if (ImGui::Button(XORSTR("OK")))
-                        ImGui::CloseCurrentPopup();
-
-                    ImGui::EndPopup();
-                }
-                ImGui::PopStyleVar();
-
-                ImGui::EndChild();
-            }
+            ImGui::Checkbox(XORSTR("Anti-Aim"), &Settings::AntiAim::enabled);
             ImGui::EndChild();
         }
     }

--- a/src/Hacks/angleindicator.cpp
+++ b/src/Hacks/angleindicator.cpp
@@ -48,10 +48,8 @@ void AngleIndicator::Paint( ) {
     Draw::AddLine( centerX, centerY, centerX, northY, fakeColor ); // Const North line
     Draw::AddLine( centerX, centerY, leftDesyncMaxX, leftDesyncMaxY, basicColor ); // Left Max
     Draw::AddLine( centerX, centerY, rightDesyncMaxX, rightDesyncMaxY, basicColor ); // Right Max
+    Draw::AddLine( centerX, centerY, realX, realY, realColor ); // Real Line
 
-    if( Settings::AntiAim::Yaw::enabled && ( Settings::AntiAim::Yaw::typeFake != Settings::AntiAim::Yaw::type)  ){
-        Draw::AddLine( centerX, centerY, realX, realY, realColor ); // Real Line
-    }
     if( Settings::AntiAim::LBYBreaker::enabled ){
         Draw::AddLine( centerX, centerY, lbyX, lbyY, lbyColor ); // LBY Line
     }

--- a/src/Hacks/antiaim.cpp
+++ b/src/Hacks/antiaim.cpp
@@ -8,25 +8,15 @@
 #include "../interfaces.h"
 #include "valvedscheck.h"
 
-bool Settings::AntiAim::Yaw::enabled = false;
-bool Settings::AntiAim::Pitch::enabled = false;
+bool Settings::AntiAim::enabled = false;
 
-AntiAimType_Y Settings::AntiAim::Yaw::type = AntiAimType_Y::NONE;
-AntiAimType_Y Settings::AntiAim::Yaw::typeFake = AntiAimType_Y::NONE;
-AntiAimType_X Settings::AntiAim::Pitch::type = AntiAimType_X::STATIC_DOWN;
-
-bool Settings::AntiAim::HeadEdge::enabled = false;
-float Settings::AntiAim::HeadEdge::distance = 25.0f;
-
-bool Settings::AntiAim::AutoDisable::noEnemy = false;
-bool Settings::AntiAim::AutoDisable::knifeHeld = false;
 bool Settings::AntiAim::LBYBreaker::enabled = false;
 float Settings::AntiAim::LBYBreaker::offset = 180.0f;
 
 QAngle AntiAim::realAngle;
 QAngle AntiAim::fakeAngle;
 
-float AntiAim::GetMaxDelta( CCSGOAnimState *animState ) {
+float AntiAim::GetMaxDelta(CCSGOAnimState *animState) {
 
     float speedFraction = std::max(0.0f, std::min(animState->feetShuffleSpeed, 1.0f));
 
@@ -46,157 +36,32 @@ float AntiAim::GetMaxDelta( CCSGOAnimState *animState ) {
     return delta - 0.5f;
 }
 
-static float Distance(Vector a, Vector b)
+static void DoAntiAim(QAngle& angle, bool bSend, CCSGOAnimState* animState, bool direction)
 {
-    return sqrt(pow(a.x - b.x, 2) + pow(a.y - b.y, 2) + pow(a.z - b.z, 2));
-}
+	float maxDelta = AntiAim::GetMaxDelta(animState);
+	float halfDelta = maxDelta / 2;
+	static bool yFlip = false;
 
-static bool GetBestHeadAngle(QAngle& angle)
-{
-    C_BasePlayer* localplayer = (C_BasePlayer*) entityList->GetClientEntity(engine->GetLocalPlayer());
+    angle.x = 89.0f;
+    if (yFlip)
+        angle.y += direction ? halfDelta : -halfDelta;
+    else
+        angle.y += direction ? -halfDelta + 180.0f : halfDelta + 180.0f;
 
-    Vector position = localplayer->GetVecOrigin() + localplayer->GetVecViewOffset();
-
-    float closest_distance = 100.0f;
-
-    float radius = Settings::AntiAim::HeadEdge::distance + 0.1f;
-    float step = M_PI * 2.0 / 8;
-
-    for (float a = 0; a < (M_PI * 2.0); a += step)
+    if (!bSend)
     {
-        Vector location(radius * cos(a) + position.x, radius * sin(a) + position.y, position.z);
-
-        Ray_t ray;
-        trace_t tr;
-        ray.Init(position, location);
-        CTraceFilter traceFilter;
-        traceFilter.pSkip = localplayer;
-        trace->TraceRay(ray, 0x4600400B, &traceFilter, &tr);
-
-        float distance = Distance(position, tr.endpos);
-
-        if (distance < closest_distance)
-        {
-            closest_distance = distance;
-            angle.y = RAD2DEG(a);
-        }
+        if (yFlip)
+            angle.y += direction ? -maxDelta : maxDelta;
+        else
+            angle.y += direction ? maxDelta : -maxDelta;
     }
-
-    return closest_distance < Settings::AntiAim::HeadEdge::distance;
-}
-static bool HasViableEnemy()
-{
-    C_BasePlayer* localplayer = (C_BasePlayer*) entityList->GetClientEntity(engine->GetLocalPlayer());
-
-    for (int i = 1; i < engine->GetMaxClients(); ++i)
-    {
-        C_BasePlayer* entity = (C_BasePlayer*) entityList->GetClientEntity(i);
-
-        if (!entity
-            || entity == localplayer
-            || entity->GetDormant()
-            || !entity->GetAlive()
-            || entity->GetImmune())
-            continue;
-
-        if( !Aimbot::friends.empty() ) // check for friends, if any
-        {
-            IEngineClient::player_info_t entityInformation;
-            engine->GetPlayerInfo(i, &entityInformation);
-
-            if (std::find(Aimbot::friends.begin(), Aimbot::friends.end(), entityInformation.xuid) != Aimbot::friends.end())
-                continue;
-        }
-
-        if (Settings::Aimbot::friendly || !Entity::IsTeamMate(entity, localplayer))
-            return true;
-    }
-
-    return false;
-}
-static void DoAntiAimY(C_BasePlayer *const localplayer, QAngle& angle, bool bSend)
-{
-    AntiAimType_Y aa_type = bSend ? Settings::AntiAim::Yaw::typeFake : Settings::AntiAim::Yaw::type;
-
-    float maxDelta = AntiAim::GetMaxDelta(localplayer->GetAnimState());
-    static bool bFlip = false;
-    //float lby = *localplayer->GetLowerBodyYawTarget();
-    switch (aa_type)
-    {
-        case AntiAimType_Y::MAX_DELTA_LEFT:
-            angle.y = AntiAim::fakeAngle.y - maxDelta;
-            break;
-        case AntiAimType_Y::MAX_DELTA_RIGHT:
-            angle.y = AntiAim::fakeAngle.y + maxDelta;
-            break;
-        case AntiAimType_Y::MAX_DELTA_FLIPPER:
-            bFlip = !bFlip;
-            angle.y -= bFlip ? maxDelta : -maxDelta;
-            break;
-        case AntiAimType_Y::MAX_DELTA_LBY_AVOID:
-
-            break;
-        default:
-            break;
-    }
-    if( bSend ){
-        AntiAim::fakeAngle.y = angle.y;
-    } else {
-        AntiAim::realAngle.y = angle.y;
-    }
-}
-
-static void DoAntiAimX(QAngle& angle, bool bFlip, bool& clamp)
-{
-    static float pDance = 0.0f;
-    AntiAimType_X aa_type = Settings::AntiAim::Pitch::type;
-
-    switch (aa_type)
-    {
-        case AntiAimType_X::STATIC_UP:
-            angle.x = -89.0f;
-            break;
-        case AntiAimType_X::STATIC_DOWN:
-            angle.x = 89.0f;
-            break;
-        case AntiAimType_X::DANCE:
-            pDance += 45.0f;
-            if (pDance > 100)
-                pDance = 0.0f;
-            else if (pDance > 75.f)
-                angle.x = -89.f;
-            else if (pDance < 75.f)
-                angle.x = 89.f;
-            break;
-        case AntiAimType_X::FRONT:
-            angle.x = 0.0f;
-            break;
-        case AntiAimType_X::STATIC_UP_FAKE:
-            angle.x = bFlip ? 89.0f : -89.0f;
-            break;
-        case AntiAimType_X::STATIC_DOWN_FAKE:
-            angle.x = bFlip ? -89.0f : 89.0f;
-            break;
-        case AntiAimType_X::LISP_DOWN:
-            clamp = false;
-            angle.x = 1800089.0f;
-            break;
-        case AntiAimType_X::ANGEL_DOWN:
-            clamp = false;
-            angle.x = 36000088.0f;
-            break;
-        case AntiAimType_X::ANGEL_UP:
-            clamp = false;
-            angle.x = 35999912.0f;
-            break;
-        default:
-            break;
-    }
+    else
+        yFlip = !yFlip;
 }
 
 void AntiAim::CreateMove(CUserCmd* cmd)
 {
-    if (!Settings::AntiAim::Yaw::enabled && !Settings::AntiAim::Pitch::enabled && !Settings::AntiAim::LBYBreaker::enabled)
+    if (!Settings::AntiAim::enabled && !Settings::AntiAim::LBYBreaker::enabled)
         return;
 
     if (Settings::Aimbot::AimStep::enabled && Aimbot::aimStepInProgress)
@@ -206,7 +71,7 @@ void AntiAim::CreateMove(CUserCmd* cmd)
     float oldForward = cmd->forwardmove;
     float oldSideMove = cmd->sidemove;
     
-    AntiAim::realAngle = AntiAim::fakeAngle = CreateMove::lastTickViewAngles;
+    // AntiAim::realAngle = AntiAim::fakeAngle = CreateMove::lastTickViewAngles;
 
     QAngle angle = cmd->viewangles;
 
@@ -226,74 +91,76 @@ void AntiAim::CreateMove(CUserCmd* cmd)
             return;
     }
 
+    if (localplayer->GetAlive() && activeWeapon->GetCSWpnData()->GetWeaponType() == CSWeaponType::WEAPONTYPE_KNIFE)
+        return;
+
     if (cmd->buttons & IN_USE || cmd->buttons & IN_ATTACK || (cmd->buttons & IN_ATTACK2 && *activeWeapon->GetItemDefinitionIndex() == ItemDefinitionIndex::WEAPON_REVOLVER))
         return;
 
     if (localplayer->GetMoveType() == MOVETYPE_LADDER || localplayer->GetMoveType() == MOVETYPE_NOCLIP)
         return;
 
-    // Knife
-    if (Settings::AntiAim::AutoDisable::knifeHeld && localplayer->GetAlive() && activeWeapon->GetCSWpnData()->GetWeaponType() == CSWeaponType::WEAPONTYPE_KNIFE)
-        return;
-
-    if (Settings::AntiAim::AutoDisable::noEnemy && localplayer->GetAlive() && !HasViableEnemy())
-        return;
-
-    QAngle edge_angle = angle;
-    bool edging_head = Settings::AntiAim::HeadEdge::enabled && GetBestHeadAngle(edge_angle);
-
     static bool bSend = true;
     bSend = !bSend;
 
     bool should_clamp = true;
-
     bool needToFlick = false;
+    float tempangle = 0.f;
     static bool lbyBreak = false;
     static float lastCheck;
+    static float nextUpdate = FLT_MAX;
     float vel2D = localplayer->GetVelocity().Length2D();//localplayer->GetAnimState()->verticalVelocity + localplayer->GetAnimState()->horizontalVelocity;
+    CCSGOAnimState* animState = localplayer->GetAnimState();
 
-    if( Settings::AntiAim::LBYBreaker::enabled ){
-
-        if( vel2D >= 0.1f || !(localplayer->GetFlags() & FL_ONGROUND) || localplayer->GetFlags() & FL_FROZEN ){
+    if (Settings::AntiAim::LBYBreaker::enabled)
+    {
+        if (vel2D >= 0.1f || !(localplayer->GetFlags() & FL_ONGROUND) || localplayer->GetFlags() & FL_FROZEN)
+        {
             lbyBreak = false;
             lastCheck = globalVars->curtime;
-        } else {
-            if( !lbyBreak && ( globalVars->curtime - lastCheck ) > 0.22 ){
-                angle.y -= Settings::AntiAim::LBYBreaker::offset;
-                lbyBreak = true;
-                lastCheck = globalVars->curtime;
-                needToFlick = true;
-            } else if( lbyBreak && ( globalVars->curtime - lastCheck ) > 1.1 ){
-                angle.y -= Settings::AntiAim::LBYBreaker::offset;
-                lbyBreak = true;
-                lastCheck = globalVars->curtime;
-                needToFlick = true;
-            }
+            nextUpdate = globalVars->curtime + 0.22;
+        }
+        else if (!lbyBreak && (globalVars->curtime - lastCheck) > 0.22 || lbyBreak && (globalVars->curtime - lastCheck) > 1.1)
+        {
+            tempangle = Settings::AntiAim::LBYBreaker::offset;
+            lbyBreak = true;
+            lastCheck = globalVars->curtime;
+            nextUpdate = globalVars->curtime + 1.1;
+            needToFlick = true;
         }
     }
 
-    if (Settings::AntiAim::Yaw::enabled && !needToFlick)
+    if ((nextUpdate - globalVars->interval_per_tick) >= globalVars->curtime && nextUpdate <= globalVars->curtime)
+        CreateMove::sendPacket = false;
+
+    static bool directionSwitch = false;
+
+    if (inputSystem->IsButtonDown(KEY_LEFT))
+		directionSwitch = true;
+	else if (inputSystem->IsButtonDown(KEY_RIGHT))
+		directionSwitch = false;
+
+    if (needToFlick)
     {
-        DoAntiAimY(localplayer, angle, bSend);
-
-        CreateMove::sendPacket = bSend;
-        if (Settings::AntiAim::HeadEdge::enabled && edging_head && !bSend)
-            angle.y = edge_angle.y;
+        CreateMove::sendPacket = false;
+        angle.y += tempangle;
     }
+    else
+    	DoAntiAim(angle, bSend, animState, directionSwitch);
 
-    if (!ValveDSCheck::forceUT && (*csGameRules) && (*csGameRules)->IsValveDS())
+    if (should_clamp)
     {
-        if (Settings::AntiAim::Pitch::type >= AntiAimType_X::STATIC_UP_FAKE)
-            Settings::AntiAim::Pitch::type = AntiAimType_X::STATIC_UP;
-    }
-
-    if (Settings::AntiAim::Pitch::enabled)
-        DoAntiAimX(angle, bSend, should_clamp);
-
-    if( should_clamp ){
         Math::NormalizeAngles(angle);
         Math::ClampAngles(angle);
     }
+
+    if (!needToFlick)
+        CreateMove::sendPacket = bSend;
+
+    if (bSend)
+        AntiAim::realAngle = CreateMove::lastTickViewAngles;
+    else
+        AntiAim::fakeAngle = angle;
 
     cmd->viewangles = angle;
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -219,15 +219,7 @@ void Settings::LoadDefaultsOrSave(std::string path)
 	settings[XORSTR("Aimbot")][XORSTR("AutoCrouch")][XORSTR("enabled")] = Settings::Aimbot::AutoCrouch::enabled;
 	settings[XORSTR("Aimbot")][XORSTR("AutoShoot")][XORSTR("velocityCheck")] = Settings::Aimbot::AutoShoot::velocityCheck;
 
-	settings[XORSTR("AntiAim")][XORSTR("AutoDisable")][XORSTR("no_enemy")] = Settings::AntiAim::AutoDisable::noEnemy;
-	settings[XORSTR("AntiAim")][XORSTR("AutoDisable")][XORSTR("knife_held")] = Settings::AntiAim::AutoDisable::knifeHeld;
-	settings[XORSTR("AntiAim")][XORSTR("Yaw")][XORSTR("enabled")] = Settings::AntiAim::Yaw::enabled;
-	settings[XORSTR("AntiAim")][XORSTR("Yaw")][XORSTR("type")] = (int) Settings::AntiAim::Yaw::type;
-	settings[XORSTR("AntiAim")][XORSTR("Yaw")][XORSTR("type_fake")] = (int) Settings::AntiAim::Yaw::typeFake;
-	settings[XORSTR("AntiAim")][XORSTR("Pitch")][XORSTR("enabled")] = Settings::AntiAim::Pitch::enabled;
-	settings[XORSTR("AntiAim")][XORSTR("Pitch")][XORSTR("type")] = (int) Settings::AntiAim::Pitch::type;
-	settings[XORSTR("AntiAim")][XORSTR("HeadEdge")][XORSTR("enabled")] = Settings::AntiAim::HeadEdge::enabled;
-	settings[XORSTR("AntiAim")][XORSTR("HeadEdge")][XORSTR("distance")] = Settings::AntiAim::HeadEdge::distance;
+	settings[XORSTR("AntiAim")][XORSTR("enabled")] = Settings::AntiAim::enabled;
 	settings[XORSTR("AntiAim")][XORSTR("LBYBreaker")][XORSTR("enabled")] = Settings::AntiAim::LBYBreaker::enabled;
 	settings[XORSTR("AntiAim")][XORSTR("LBYBreaker")][XORSTR("offset")] = Settings::AntiAim::LBYBreaker::offset;
 
@@ -734,15 +726,7 @@ void Settings::LoadConfig(std::string path)
 	GetVal(settings[XORSTR("Aimbot")][XORSTR("AutoCrouch")][XORSTR("enabled")], &Settings::Aimbot::AutoCrouch::enabled);
 	GetVal(settings[XORSTR("Aimbot")][XORSTR("AutoShoot")][XORSTR("velocityCheck")], &Settings::Aimbot::AutoShoot::velocityCheck);
 
-	GetVal(settings[XORSTR("AntiAim")][XORSTR("AutoDisable")][XORSTR("no_enemy")], &Settings::AntiAim::AutoDisable::noEnemy);
-	GetVal(settings[XORSTR("AntiAim")][XORSTR("AutoDisable")][XORSTR("knife_held")], &Settings::AntiAim::AutoDisable::knifeHeld);
-	GetVal(settings[XORSTR("AntiAim")][XORSTR("Yaw")][XORSTR("enabled")], &Settings::AntiAim::Yaw::enabled);
-	GetVal(settings[XORSTR("AntiAim")][XORSTR("Yaw")][XORSTR("type")], (int*)&Settings::AntiAim::Yaw::type);
-	GetVal(settings[XORSTR("AntiAim")][XORSTR("Yaw")][XORSTR("type_fake")], (int*)&Settings::AntiAim::Yaw::typeFake);
-	GetVal(settings[XORSTR("AntiAim")][XORSTR("Pitch")][XORSTR("enabled")], &Settings::AntiAim::Pitch::enabled);
-	GetVal(settings[XORSTR("AntiAim")][XORSTR("Pitch")][XORSTR("type")], (int*)&Settings::AntiAim::Pitch::type);
-	GetVal(settings[XORSTR("AntiAim")][XORSTR("HeadEdge")][XORSTR("enabled")], &Settings::AntiAim::HeadEdge::enabled);
-	GetVal(settings[XORSTR("AntiAim")][XORSTR("HeadEdge")][XORSTR("distance")], &Settings::AntiAim::HeadEdge::distance);
+	GetVal(settings[XORSTR("AntiAim")][XORSTR("enabled")], &Settings::AntiAim::enabled);
 	GetVal(settings[XORSTR("AntiAim")][XORSTR("LBYBreaker")][XORSTR("enabled")], &Settings::AntiAim::LBYBreaker::enabled);
 	GetVal(settings[XORSTR("AntiAim")][XORSTR("LBYBreaker")][XORSTR("offset")], &Settings::AntiAim::LBYBreaker::offset);
 

--- a/src/settings.h
+++ b/src/settings.h
@@ -151,28 +151,6 @@ enum class ShowedAngle : int
     FAKE,
 };
 
-enum class AntiAimType_Y : int
-{
-	NONE,
-    MAX_DELTA_LEFT,
-	MAX_DELTA_RIGHT,
-    MAX_DELTA_FLIPPER,
-    MAX_DELTA_LBY_AVOID,
-};
-
-enum class AntiAimType_X : int
-{
-    STATIC_UP,
-    STATIC_DOWN,
-    DANCE,
-    FRONT,
-    STATIC_UP_FAKE,
-    STATIC_DOWN_FAKE,
-    LISP_DOWN,
-    ANGEL_DOWN,
-    ANGEL_UP,
-};
-
 struct AimbotWeapon_t
 {
 	bool enabled,
@@ -551,30 +529,8 @@ namespace Settings
 
     namespace AntiAim
     {
-        namespace AutoDisable
-        {
-            extern bool noEnemy;
-            extern bool knifeHeld;
-        }
+		extern bool enabled;
 
-        namespace Yaw
-        {
-            extern bool enabled;
-            extern AntiAimType_Y type;
-            extern AntiAimType_Y typeFake;
-        }
-
-        namespace Pitch
-        {
-            extern bool enabled;
-            extern AntiAimType_X type;
-        }
-
-        namespace HeadEdge
-        {
-            extern bool enabled;
-            extern float distance;
-        }
         namespace LBYBreaker
         {
             extern bool enabled;


### PR DESCRIPTION
Hey, long time no see!

I made an anti-aim, which could be a better solution to the one that is in Fuzion already. This anti-aim that is the same as @acuifex 's, but I wanted to remove the parts of Fuzion that are not working correctly. I have a source code of an improved version of the last one, which I turned into a legit anti-aim.

First, I am curious if you even want to use this one instead. Check it out on my fork.

- Removed yaw options
- Removed pitch options
- Removed auto-disable options
- Removed head-edge
- Added new rage anti-aim