### PR TITLE
Fix occasional question marks on ingame radar

### DIFF
--- a/src/Hacks/radar.cpp
+++ b/src/Hacks/radar.cpp
@@ -294,6 +294,7 @@ static void InGameRadar(C_BasePlayer* player)
 		return;
 
 	*player->GetSpotted() = true;
+	*player->GetSpottedByMask() = -1;
 }
 
 

--- a/src/SDK/IClientEntity.h
+++ b/src/SDK/IClientEntity.h
@@ -246,6 +246,11 @@ public:
 	{
 		return (bool*)((uintptr_t)this + offsets.DT_BaseEntity.m_bSpotted);
 	}
+
+	uint32_t *GetSpottedByMask()
+	{
+		return (uint32_t *)((uintptr_t)this + offsets.DT_BaseEntity.m_bSpottedByMask);
+	}
 };
 
 /* generic game classes */

--- a/src/offsets.cpp
+++ b/src/offsets.cpp
@@ -31,6 +31,7 @@ void Offsets::GetNetVarOffsets()
 	offsets.DT_BaseEntity.m_MoveType = offsets.DT_BaseEntity.m_nRenderMode + 1;
 	offsets.DT_BaseEntity.m_Collision = NetVarManager::GetOffset(tables, XORSTR("DT_BaseEntity"), XORSTR("m_Collision"));
 	offsets.DT_BaseEntity.m_bSpotted = NetVarManager::GetOffset(tables, XORSTR("DT_BaseEntity"), XORSTR("m_bSpotted"));
+	offsets.DT_BaseEntity.m_bSpottedByMask = NetVarManager::GetOffset(tables, XORSTR("DT_BaseEntity"), XORSTR("m_bSpottedByMask"));
 
 	offsets.DT_BaseCombatCharacter.m_hActiveWeapon = NetVarManager::GetOffset(tables, XORSTR("DT_BaseCombatCharacter"), XORSTR("m_hActiveWeapon"));
 	offsets.DT_BaseCombatCharacter.m_hMyWeapons = NetVarManager::GetOffset(tables, XORSTR("DT_BaseCombatCharacter"), XORSTR("m_hMyWeapons")) / 2;

--- a/src/offsets.h
+++ b/src/offsets.h
@@ -32,6 +32,7 @@ struct COffsets
 		std::ptrdiff_t m_MoveType;
 		std::ptrdiff_t m_Collision;
 		std::ptrdiff_t m_bSpotted;
+		std::ptrdiff_t m_bSpottedByMask;
 	} DT_BaseEntity;
 
 	struct


### PR DESCRIPTION
This PR aims to remove the question marks on the minimap radar.
Before, when another unspots an enemy (With the Fuzion radar enabled) a question mark would appear, as this is the regular behavior in csgo.

Before:
![image](https://user-images.githubusercontent.com/69584023/90012527-d0dac680-dca3-11ea-9dbd-078a47d7e85b.png)
(Ingame Radar Hack on, Question mark appears)

Explanation:
The spotted mask is a bitfield that stores which players have spotted an entity.
`uint32_t(-1)` (`0b11111111111111111111111111111111`) toggles all bits to 1, meaning every player has spotted the entity.
Now, when another player unspots the entity, and the mask is checked, csgo thinks other players still see it, therefore the question mark is not shown.