### PR TITLE
update CCSWeaponInfo offsets and FindLineGoesThroughSmoke pattern

### DIFF
--- a/src/SDK/IClientEntity.h
+++ b/src/SDK/IClientEntity.h
@@ -658,35 +658,37 @@ public:
 	}
 
 	float GetWeaponArmorRatio() {
-		return *( float* ) ( ( uintptr_t )this + 0x170);
+		return *( float* ) ( ( uintptr_t )this + 0x174);
 	}
 
 	float GetPenetration() {
-		return *( float* ) ( ( uintptr_t )this + 0x178);
+		return *( float* ) ( ( uintptr_t )this + 0x17C);
 	}
 
 	float GetRange() {
-		return *( float* ) ( ( uintptr_t )this + 0x184);
-	}
-
-	float GetRangeModifier() {
 		return *( float* ) ( ( uintptr_t )this + 0x188);
 	}
 
-	float GetMaxPlayerSpeed() {
-		return *( float* ) ( ( uintptr_t )this + 0x1B0);
+	float GetRangeModifier() {
+		return *( float* ) ( ( uintptr_t )this + 0x18C);
 	}
 
+	float GetMaxPlayerSpeed() {
+		return *( float* ) ( ( uintptr_t )this + 0x1B8);
+	}
+
+	// i haven't updated the offset of this since 22 september 2021 (shark operation or whatever)
+	// should be 0x8 to 0x10 higher
 	int GetZoomLevels() { // Doesn't work correctly on some weapons.
 		return *( int* ) ( ( uintptr_t )this + 0x23C); // DT_WeaponCSBaseGun.m_zoomLevel ?
 	}
 
 	char* GetTracerEffect() {
-		return *( char** ) ( ( uintptr_t )this + 0x280);
+		return *( char** ) ( ( uintptr_t )this + 0x290);
 	}
 
 	int* GetTracerFrequency() {
-		return ( int* ) ( ( uintptr_t )this + 0x288);
+		return ( int* ) ( ( uintptr_t )this + 0x298);
 	}
 };
 

--- a/src/hooker.cpp
+++ b/src/hooker.cpp
@@ -282,8 +282,8 @@ void Hooker::FindGetLocalClient()
 void Hooker::FindLineGoesThroughSmoke()
 {
 	uintptr_t func_address = PatternFinder::FindPatternInModule(XORSTR("/client_client.so"),
-																(unsigned char*) XORSTR("\x40\x0F\xB6\xFF\x55"),
-																XORSTR("xxxxx"));
+                                                                    (unsigned char*) XORSTR("\x55\x48\x89\xe5\x41\x56\x41\x55\x41\x54\x53\x48\x83\xec\x30\x66\x0f\xd6\x45\xd0\x8b\x0d"),
+                                                                    XORSTR("xxxxxxxxxxxxxxxxxxx?xx"));
 	LineGoesThroughSmoke = reinterpret_cast<LineGoesThroughSmokeFn>(func_address);
 }
 


### PR DESCRIPTION
this is an addition to https://github.com/LWSS/Fuzion/pull/652